### PR TITLE
UHF-4153: Change front page to correct node, add functional breadcrumb

### DIFF
--- a/conf/cmi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/easy_breadcrumb.settings.yml
@@ -1,12 +1,12 @@
 _core:
   default_config_hash: azWBxQFowXKyqUvvROIrMBXpwGaxz4JxhL6xz420P3Q
-applies_admin_routes: true
+applies_admin_routes: false
 include_invalid_paths: false
 excluded_paths: ''
 replaced_titles: ''
 custom_paths: ''
 include_home_segment: false
-alternative_title_field: field_breadcrumb_title
+alternative_title_field: ''
 home_segment_title: Home
 home_segment_keep: false
 include_title_segment: true
@@ -17,16 +17,16 @@ use_page_title_as_menu_title_fallback: false
 remove_repeated_segments: true
 language_path_prefix_as_segment: false
 absolute_paths: false
-hide_single_home_item: false
+hide_single_home_item: true
 term_hierarchy: false
 use_site_title: false
 add_structured_data_json_ld: false
-capitalizator_mode: ucwords
+capitalizator_mode: none
 capitalizator_ignored_words: {  }
 capitalizator_forced_words: {  }
 capitalizator_forced_words_case_sensitivity: true
 capitalizator_forced_words_first_letter: false
-follow_redirects: true
+follow_redirects: false
 limit_segment_display: false
 segment_display_limit: ''
 truncator_mode: false

--- a/conf/cmi/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/helfi_base_config.breadcrumb.yml
@@ -1,5 +1,5 @@
 langcode: en
 breadcrumb_base_links:
   -
-    text: ''
-    url: ''
+    text: Frontpage
+    url: 'https://www.hel.fi/helsinki/en'

--- a/conf/cmi/helfi_proxy.settings.yml
+++ b/conf/cmi/helfi_proxy.settings.yml
@@ -1,3 +1,5 @@
+langcode: en
+front_page_title: 'Business and Work'
 asset_path: elo-assets
 prefixes:
   en: business-and-work

--- a/conf/cmi/language/fi/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/language/fi/helfi_base_config.breadcrumb.yml
@@ -1,0 +1,4 @@
+breadcrumb_base_links:
+  -
+    text: Etusivu
+    url: 'https://www.hel.fi/helsinki/fi'

--- a/conf/cmi/language/fi/helfi_proxy.settings.yml
+++ b/conf/cmi/language/fi/helfi_proxy.settings.yml
@@ -1,0 +1,1 @@
+front_page_title: 'Yritykset ja työ'

--- a/conf/cmi/language/sv/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/language/sv/helfi_base_config.breadcrumb.yml
@@ -1,0 +1,4 @@
+breadcrumb_base_links:
+  -
+    text: Framsida
+    url: 'https://www.hel.fi/helsinki/sv'

--- a/conf/cmi/language/sv/helfi_proxy.settings.yml
+++ b/conf/cmi/language/sv/helfi_proxy.settings.yml
@@ -1,0 +1,1 @@
+front_page_title: 'Företag och arbete'

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /user/login
+  front: /node/1
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en


### PR DESCRIPTION
How to test:

1. Set up your local with a dump from production.
2. Checkout this branch and run `make drush-cim && make drush-cr`
3. Make sure that the front page of the instance is now node/1 and not the login screen.
4. Make sure the breadcrumb is now similar to all other live instances.