### PR TITLE
UHF-4153: Change the front page to point to front-path

### DIFF
--- a/conf/cmi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/easy_breadcrumb.settings.yml
@@ -5,9 +5,9 @@ include_invalid_paths: false
 excluded_paths: ''
 replaced_titles: ''
 custom_paths: ''
-include_home_segment: false
+include_home_segment: true
 alternative_title_field: ''
-home_segment_title: Home
+home_segment_title: 'Business and Work'
 home_segment_keep: false
 include_title_segment: true
 title_from_page_when_available: true

--- a/conf/cmi/language/fi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/language/fi/easy_breadcrumb.settings.yml
@@ -1,1 +1,1 @@
-home_segment_title: Etusivu
+home_segment_title: 'Yritykset ja työ'

--- a/conf/cmi/language/sv/easy_breadcrumb.settings.yml
+++ b/conf/cmi/language/sv/easy_breadcrumb.settings.yml
@@ -1,1 +1,1 @@
-home_segment_title: Hem
+home_segment_title: 'Företag och arbete'

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /node/1
+  front: /front
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en


### PR DESCRIPTION
How to test:

1. Checkout this branch and run `make drush-cr`
2. Now you front page should redirect to path '/front' which is empty unless you add a redirect to that path that takes you to the desired front page.
3. Also make sure the breadcrumb has now the link to hel.fi as first link, the front page as second and the content you are on next etc..