### PR TITLE
UHF-4258: Add React & Share block for ELO

### DIFF
--- a/conf/cmi/block.block.reactandshare.yml
+++ b/conf/cmi/block.block.reactandshare.yml
@@ -1,6 +1,6 @@
 uuid: f07388ba-d88d-4f94-9029-feae9b0be4fd
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - helfi_platform_config


### PR DESCRIPTION
How to test:

1. Checkout this branch
2. `make drush-cim && make drush-cr`
3. Edit your local.settings.php (create one if you don't have it) and add the React & Share API keys
`putenv('REACT_AND_SHARE_APIKEY_FI=gjhfvh3m4xcvnred');`
`putenv('REACT_AND_SHARE_APIKEY_SV=mwft0afec1l7d6g1');`
`putenv('REACT_AND_SHARE_APIKEY_EN=7zfblho0j7sm0url');`
4. Go to any part of the site and you should see the React & Share block there on the bottom of the page.