### PR TITLE
UHF-6300: Remove ctools site specific configs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3920,16 +3920,16 @@
         },
         {
             "name": "drupal/hdbt",
-            "version": "3.0.22",
+            "version": "3.0.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-hdbt.git",
-                "reference": "6bb6d24a8de9c242b8d09fe60073fd899a350d52"
+                "reference": "52f9b623921c700c1e92afc8e95cf07c1e5c3265"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/6bb6d24a8de9c242b8d09fe60073fd899a350d52",
-                "reference": "6bb6d24a8de9c242b8d09fe60073fd899a350d52",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/52f9b623921c700c1e92afc8e95cf07c1e5c3265",
+                "reference": "52f9b623921c700c1e92afc8e95cf07c1e5c3265",
                 "shasum": ""
             },
             "require": {
@@ -3944,10 +3944,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/3.0.22",
+                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/3.0.23",
                 "issues": "https://github.com/City-of-Helsinki/drupal-hdbt/issues"
             },
-            "time": "2022-08-12T07:59:25+00:00"
+            "time": "2022-08-29T04:59:02+00:00"
         },
         {
             "name": "drupal/hdbt_admin",
@@ -4147,16 +4147,16 @@
         },
         {
             "name": "drupal/helfi_platform_config",
-            "version": "2.9.18",
+            "version": "2.9.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config.git",
-                "reference": "71679d2837c6cf7ec4b34c5ad0644f85da4867e9"
+                "reference": "61ba500e2916aada42b40fbc73f97e36933625cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/71679d2837c6cf7ec4b34c5ad0644f85da4867e9",
-                "reference": "71679d2837c6cf7ec4b34c5ad0644f85da4867e9",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/61ba500e2916aada42b40fbc73f97e36933625cb",
+                "reference": "61ba500e2916aada42b40fbc73f97e36933625cb",
                 "shasum": ""
             },
             "require": {
@@ -4176,7 +4176,7 @@
                 "drupal/elasticsearch_connector": "^7.0@alpha",
                 "drupal/entity_browser": "^2.5",
                 "drupal/entity_usage": "^2.0@beta",
-                "drupal/eu_cookie_compliance": "^1.14",
+                "drupal/eu_cookie_compliance": "1.19",
                 "drupal/external_entities": "^2.0@alpha",
                 "drupal/features": "^3.12",
                 "drupal/field_group": "^3.1",
@@ -4269,10 +4269,10 @@
             ],
             "description": "HELfi platform config",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.9.18",
+                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.9.20",
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
-            "time": "2022-08-11T11:34:32+00:00"
+            "time": "2022-08-29T12:53:09+00:00"
         },
         {
             "name": "drupal/helfi_proxy",

--- a/conf/cmi/block.block.hdbt_page_title.yml
+++ b/conf/cmi/block.block.hdbt_page_title.yml
@@ -2,8 +2,6 @@ uuid: 0ee3a299-8960-461a-8a6e-7346be8cfef7
 langcode: en
 status: true
 dependencies:
-  module:
-    - ctools
   theme:
     - hdbt
 _core:

--- a/conf/cmi/block.block.heroblock.yml
+++ b/conf/cmi/block.block.heroblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - ctools
     - hdbt_content
   theme:
     - hdbt

--- a/conf/cmi/block.block.main_navigation_level_2.yml
+++ b/conf/cmi/block.block.main_navigation_level_2.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - system.menu.main
   module:
-    - ctools
     - menu_block_current_language
   theme:
     - hdbt

--- a/conf/cmi/block.block.sidebarcontentblock.yml
+++ b/conf/cmi/block.block.sidebarcontentblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - ctools
     - hdbt_content
   theme:
     - hdbt

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -16,7 +16,6 @@ module:
   content_lock: 0
   content_lock_timeout: 0
   crop: 0
-  ctools: 0
   datetime: 0
   dblog: 0
   diff: 0


### PR DESCRIPTION
# [UHF-6300](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6300)

After pathauto 8.x-1.11 release, which removed the ctools dependency, ctools is longer needed.

## What was done
* Made sure that pathauto is updated to version 8.x-1.11.
* Removed ctools dependencies from site specific configs, if any.
* Uninstalled ctools using site configs.
* This PR is marked as draft until the related releases for _hdbt_ and _platform config_ are done and this PR is updated to use those releases.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6300-elo-remove-ctools`
* `make shell` and
  * `composer require drupal/helfi_platform_config:dev-UHF-6300-remove-ctools`
  * `composer require drupal/hdbt:dev-UHF-6300-hdbt-remove-ctools`
* `make fresh`
* Run `make drush-cr`

## How to test
* Check that the ctools module is disabled and the site still seems to work correctly.
* [x] Check that this feature works
* [x] Check that code follows our standards

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
* Theme and module updates:
  * https://github.com/City-of-Helsinki/drupal-hdbt/pull/382
  * https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/352
* Other site specific PRs:
  * https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/435
  * https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/419
  * https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/308
  * https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/204
  * https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/95
  * https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/43
  * https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/114