### PR TITLE
UHF-7242 update anonymous permissions

### DIFF
--- a/conf/cmi/user.role.anonymous.yml
+++ b/conf/cmi/user.role.anonymous.yml
@@ -19,6 +19,5 @@ permissions:
   - 'display eu cookie compliance popup'
   - 'view media'
   - 'view remote entities'
-  - 'view tpr_ontology_word_details'
   - 'view tpr_service'
   - 'view tpr_unit'

--- a/conf/cmi/user.role.anonymous.yml
+++ b/conf/cmi/user.role.anonymous.yml
@@ -11,7 +11,7 @@ dependencies:
 _core:
   default_config_hash: j5zLMOdJBqC0bMvSdth5UebkprJB8g_2FXHqhfpJzow
 id: anonymous
-label: 'Anonyymi käyttäjä'
+label: 'Anonymous user'
 weight: 0
 is_admin: false
 permissions:

--- a/conf/cmi/user.role.anonymous.yml
+++ b/conf/cmi/user.role.anonymous.yml
@@ -5,12 +5,13 @@ dependencies:
   module:
     - eu_cookie_compliance
     - helfi_api_base
+    - helfi_tpr
     - media
     - system
 _core:
   default_config_hash: j5zLMOdJBqC0bMvSdth5UebkprJB8g_2FXHqhfpJzow
 id: anonymous
-label: 'Anonymous user'
+label: 'Anonyymi käyttäjä'
 weight: 0
 is_admin: false
 permissions:
@@ -18,3 +19,6 @@ permissions:
   - 'display eu cookie compliance popup'
   - 'view media'
   - 'view remote entities'
+  - 'view tpr_ontology_word_details'
+  - 'view tpr_service'
+  - 'view tpr_unit'


### PR DESCRIPTION
[UHF-7252](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7242) Allowed anonymous user to see published TPR-content

## How to install
* Make sure your instance is up and running on correct branch.
  * git pull origin UHF-7242_update_anonymous_permissions
  * make fresh

## How to test
* Login as admin
* Go to `/en/business-and-work/admin/content/integrations`
* Enable one of the entities from one of the TPR contents
  * Copy a view link to the entity you just enabled
* Open another browser window in incognito
  * Go to the view link you just copied

You should see the content of the published entity instead of error page as unauthenticated user.