### PR TITLE
UHF-7241: Updated Swedish translation for front page in the breadcrumb.

### DIFF
--- a/conf/cmi/language/sv/metatag.metatag_defaults.front.yml
+++ b/conf/cmi/language/sv/metatag.metatag_defaults.front.yml
@@ -1,1 +1,1 @@
-label: Startsida
+label: Huvudsida


### PR DESCRIPTION
# [UHF-7241](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7241)
Swedish translation for front page is wrong in the breadcrumb.

## What was done

* Updated Swedish translation for front page in the breadcrumb from **Startsida** to **Huvudsida**.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7241_elo-breadcrumb-translation-fix`
* Run `make drush-cim`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the front page breadcrumb link text says **Huvudsida**

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review


[UHF-7241]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Other PRs
https://github.com/City-of-Helsinki/drupal-helfi-kuva/pull/116
https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/391
https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/186
https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/188
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/568
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/508
https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/181
https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/290