### PR TITLE
UHF-9060: Update helfi_tunnistamo to 3.0.0 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "drupal/helfi_platform_config": "^3.0",
         "drupal/helfi_proxy": "^3.0",
         "drupal/helfi_tpr": "^2.0",
-        "drupal/helfi_tunnistamo": "^2.0",
+        "drupal/helfi_tunnistamo": "^3.0",
         "drupal/raven": "^4.0",
         "drupal/redis": "^1.5",
         "drupal/stage_file_proxy": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d0f7257fe65e4b184e1199c6838c7cc",
+    "content-hash": "c281162f7165d8fee78fe49765383619",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4212,16 +4212,16 @@
         },
         {
             "name": "drupal/helfi_tunnistamo",
-            "version": "2.2.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-tunnistamo.git",
-                "reference": "17badf64ebfcc6a30458634b19a4387cb4ce3d34"
+                "reference": "29e98d8a1c9fd39a98da7ce2b44fdc28a614bd99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tunnistamo/zipball/17badf64ebfcc6a30458634b19a4387cb4ce3d34",
-                "reference": "17badf64ebfcc6a30458634b19a4387cb4ce3d34",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tunnistamo/zipball/29e98d8a1c9fd39a98da7ce2b44fdc28a614bd99",
+                "reference": "29e98d8a1c9fd39a98da7ce2b44fdc28a614bd99",
                 "shasum": ""
             },
             "require": {
@@ -4238,10 +4238,10 @@
             ],
             "description": "Tunnistamo integration",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tunnistamo/tree/2.2.4",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tunnistamo/tree/3.0.0",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-tunnistamo/issues"
             },
-            "time": "2023-05-17T11:53:24+00:00"
+            "time": "2023-08-28T07:28:23+00:00"
         },
         {
             "name": "drupal/image_style_quality",


### PR DESCRIPTION
# [UHF-9060](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9060)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* helfi_tunnistamo was updated to latest version.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9060`
  * `make fresh`
* Run `make drush-cr drush-updb`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure that the helfi_tunnistamo is running version 3.0.0 and that logging into the site still works.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-9060]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ